### PR TITLE
Update Dalamud API to 15

### DIFF
--- a/MonsterLootHunter/MonsterLootHunter.csproj
+++ b/MonsterLootHunter/MonsterLootHunter.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
     <PropertyGroup>
         <Authors>Sylf</Authors>
         <Company>Guiomarino Dev</Company>
@@ -36,8 +36,6 @@
     <ItemGroup>
         <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
         <PackageReference Include="Fizzler.Systems.HtmlAgilityPack" Version="1.2.1" />
-        <PackageReference Include="XivCommon" Version="9.0.0" />
-        <PackageReference Update="DalamudPackager" Version="14.0.1" />
     </ItemGroup>
     <ItemGroup>
       <Compile Update="Data\Gatherable\GatheringNode.Items.cs">

--- a/MonsterLootHunter/MonsterLootHunter.json
+++ b/MonsterLootHunter/MonsterLootHunter.json
@@ -5,7 +5,7 @@
   "Description": "Check where you can obtain a material from monsters, duties, crafting, gathering or where they can be bought from NPCs.",
   "InternalName": "monsterLootHunter",
   "ApplicableVersion": "any",
-  "Changelog": "- Update for API 14\n- Loot data cache\n- Refactors on code",
+  "Changelog": "- Update for API 15\n- Loot data cache\n- Refactors on code",
   "AssemblyVersion": "1.5.24.7",
   "RepoUrl": "https://github.com/danielbrenom/MonsterLootHunter",
   "Tags": [

--- a/MonsterLootHunter/packages.lock.json
+++ b/MonsterLootHunter/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
@@ -29,12 +29,6 @@
         "requested": "[1.12.4, )",
         "resolved": "1.12.4",
         "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
-      },
-      "XivCommon": {
-        "type": "Direct",
-        "requested": "[9.0.0, )",
-        "resolved": "9.0.0",
-        "contentHash": "avaBp3FmSCi/PiQhntCeBDYOHejdyTWmFtz4pRBVQQ8vHkmRx+YTk1la9dkYBMlXxRXKckEdH1iI1Fu61JlE7w=="
       },
       "Fizzler": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

Updates MonsterLootHunter to Dalamud API 15.

## Changes

- Bumped `Dalamud.NET.Sdk` from `14.0.1` to `15.0.0`
- Removed explicit `DalamudPackager` reference, since it is provided by the Dalamud SDK
- Removed unused `XivCommon` dependency
- Updated the plugin manifest changelog from API 14 to API 15
- Refreshed `packages.lock.json`

## Testing

- Built successfully with:

```powershell
dotnet build MonsterLootHunter.sln -c Release -p:Platform=x64
```

Result: `0 warnings`, `0 errors`.

- Loaded the plugin in-game and did a brief smoke test to confirm it starts and basic usage works.
